### PR TITLE
Implement TRUST_PROXY configuration to enhance login rate limiting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,14 @@ VAULT_HOST_PATH=./sample-vault
 HTTP_BIND=0.0.0.0
 HTTP_PORT=8787
 
+# Proxy trust. Keep "false" when the container is exposed directly: it stops the
+# app from trusting client-supplied X-Forwarded-For (which could otherwise be
+# spoofed to bypass the login rate limit). Set ONLY when behind a real reverse
+# proxy: "true" (trust the immediate hop), a hop count, or a subnet/preset list
+# (e.g. "loopback, 10.0.0.0/8"). Required for X-Forwarded-Proto-based HTTPS cookie
+# detection when TLS is terminated at the proxy.
+TRUST_PROXY=false
+
 # Initial master password. Leave empty to set it on first-run via the UI.
 WEBOBSIDIAN_PASSWORD=
 

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ desktop/.gen/
 desktop/release/
 # Local agent runbooks/skills — may contain server creds; never commit.
 .claude/skills/
+report.md

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -4,7 +4,7 @@
 > Quy ước: `[ ]` chưa làm · `[~]` đang làm · `[x]` xong.
 > Cập nhật file này **mỗi khi** một mục thay đổi trạng thái.
 
-Cập nhật lần cuối: 2026-06-23 (fix — internal link tới file `.canvas` mở đúng canvas thay vì tạo `*.canvas.md`)
+Cập nhật lần cuối: 2026-06-24 (security fix F-03 — vá bypass rate-limit login qua `X-Forwarded-For`)
 
 ---
 
@@ -430,6 +430,15 @@ Cập nhật lần cuối: 2026-06-23 (fix — internal link tới file `.canvas
       `desktop/release`.
 
 ### Nhật ký tiến độ
+- 2026-06-24 (security fix F-03 — bypass rate-limit login qua `X-Forwarded-For`): trước đây
+  `app.set('trust proxy', 1)` luôn bật ⇒ `req.ip` lấy từ `X-Forwarded-For`; instance lộ trực tiếp
+  (bind `0.0.0.0`) cho phép attacker tự đặt XFF mỗi request → mỗi "IP" một bucket → vượt giới hạn
+  10 lần/15 phút (brute-force pass mặc định 6 ký tự). **Sửa 3 chỗ:** (1) `server/src/config.ts` —
+  thêm `trustProxy` parse từ env `TRUST_PROXY`, **mặc định `false`** (không tin XFF khi không có proxy);
+  nhận `true`/số hop/danh sách subnet. (2) `server/src/index.ts` — `app.set('trust proxy', config.trustProxy)`
+  thay cho giá trị cứng `1`. (3) `server/src/middleware/ratelimit.ts` — limiter khóa theo
+  `req.socket.remoteAddress` (địa chỉ TCP peer **không thể giả mạo**) thay cho `req.ip`, nên throttle
+  giữ vững bất kể cấu hình `trust proxy`. Cập nhật PRD (FR-9 env `TRUST_PROXY` + NFR bảo mật). Typecheck sạch.
 - 2026-06-23 (fix — internal link tới file `.canvas`): click wikilink trỏ tới `Foo.canvas` bị điều hướng sang
   note markdown mới `Foo.canvas.md`. Nguyên nhân: link graph (`keyToPath`) chỉ index file markdown nên
   `/api/.../resolve` trả `null` cho target có đuôi `.canvas` → client rơi vào nhánh tạo note & nối thêm `.md`.

--- a/PRD.md
+++ b/PRD.md
@@ -268,7 +268,8 @@ webobsidian/
 - Healthcheck (`start_period` đủ dài cho index vault lớn lần đầu), restart policy.
 - **Self-deploy không sửa file tracked**: mọi tham số deploy đặt qua `.env` (git-ignored) —
   `VAULT_HOST_PATH` (host vault → `/vault`), `HTTP_BIND`/`HTTP_PORT` (publish), `WEBOBSIDIAN_PASSWORD`,
-  `WEBOBSIDIAN_WATCH`. `docker-compose.yml` chỉ tham chiếu `${VAR:-default}` nên `git pull`/redeploy
+  `WEBOBSIDIAN_WATCH`, `TRUST_PROXY` (mặc định `false` — chỉ bật khi đứng sau reverse proxy thật; nhận
+  `true`/số hop/danh sách subnet để Express tin `X-Forwarded-*`). `docker-compose.yml` chỉ tham chiếu `${VAR:-default}` nên `git pull`/redeploy
   không clobber cấu hình của người tự host. `cp .env.example .env && docker compose up -d --build`.
 - **File watcher chịu lỗi inotify**: VPS sạch thường có `fs.inotify.max_user_watches` thấp →
   native watch lỗi `ENOSPC/EMFILE`. Watcher tự degrade sang **polling** (`WEBOBSIDIAN_WATCH=auto`),
@@ -412,7 +413,9 @@ Express + SPA hiện có (không fork code, không đổi kiến trúc) — nên
 ## 4. Yêu cầu phi chức năng (NFR)
 - **Bảo mật**: password hash scrypt, JWT secret tự sinh, API key hash khi lưu, path traversal guard
   (chặn `..`, segment `.git`, symlink thoát vault), CORS hạn chế, rate limiting (cả `/auth/login`:
-  10 lần/15 phút/IP). Bắt buộc đổi mật khẩu mặc định (`123456`) ngay sau lần đăng nhập đầu
+  10 lần/15 phút — **khóa theo địa chỉ socket TCP thật, không theo `req.ip`/`X-Forwarded-For`** nên
+  không thể bypass bằng cách xoay vòng XFF; `trust proxy` mặc định `false`, chỉ bật qua `TRUST_PROXY`
+  khi có reverse proxy thật). Bắt buộc đổi mật khẩu mặc định (`123456`) ngay sau lần đăng nhập đầu
   (`mustChangePassword`). Security headers qua `helmet` + CSP (script-src 'self'+nonce; không ép HTTPS
   để giữ self-host HTTP). Token git/PAT được redact khỏi mọi thông báo lỗi trả client + log. WebSocket
   `/ws` yêu cầu phiên đăng nhập hợp lệ. Plugin `id` được validate trước khi thành path segment; đổi

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,7 +31,11 @@ safely. Key points:
 - Secrets (git token, API keys) live in `data/settings.json` on the server — mount `/data`
   as a private volume and keep it out of version control.
 - Run behind a TLS-terminating reverse proxy (set `HTTP_BIND=127.0.0.1`) for any
-  internet-facing deployment.
+  internet-facing deployment. When you do, set `TRUST_PROXY` to match your proxy
+  topology (e.g. `true` or a subnet list) so `X-Forwarded-Proto` is honoured.
+  Leave `TRUST_PROXY=false` (default) for directly-exposed instances — the login
+  rate limit is keyed on the real TCP socket address regardless, so it cannot be
+  bypassed by rotating `X-Forwarded-For`.
 
 ## Supported versions
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,10 @@ services:
       WEBOBSIDIAN_PASSWORD: ${WEBOBSIDIAN_PASSWORD:-}
       # File-watch mode: auto (native + polling fallback) | polling. See .env.example.
       WEBOBSIDIAN_WATCH: ${WEBOBSIDIAN_WATCH:-auto}
+      # Proxy trust. Keep "false" when exposed directly (don't trust X-Forwarded-For,
+      # which could be spoofed to bypass the login rate limit). Set to "true"/hop
+      # count/subnet list ONLY behind a real reverse proxy. See .env.example.
+      TRUST_PROXY: ${TRUST_PROXY:-false}
       VAULT_PATH: /vault
       DATA_DIR: /data
       ALLOWED_ROOTS: /vault

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -11,6 +11,14 @@ export interface RuntimeConfig {
   allowedRoots: string[];
   initialPassword?: string;
   isProd: boolean;
+  /**
+   * Express `trust proxy` setting. Controls whether `X-Forwarded-*` headers are
+   * honoured (and thus whether `req.ip`/`req.secure` derive from them). Defaults
+   * to `false` so a directly-exposed instance never trusts client-supplied
+   * `X-Forwarded-For` (which would let attackers spoof their IP to bypass the
+   * login rate limit — see security report F-03).
+   */
+  trustProxy: boolean | number | string;
 }
 
 function resolveRoots(): string[] {
@@ -21,6 +29,26 @@ function resolveRoots(): string[] {
   return [];
 }
 
+/**
+ * Parse the `TRUST_PROXY` env into an Express `trust proxy` value. Safe default
+ * is `false` (no proxy → don't honour X-Forwarded-For). Accepts:
+ *   - unset / 'false' / 'off' / '0' / '' → false
+ *   - 'true' / 'on'                      → true (trust the immediate peer)
+ *   - a non-negative integer             → number of trusted proxy hops
+ *   - anything else                      → passed through as a subnet/preset
+ *                                          list (e.g. 'loopback, 10.0.0.0/8').
+ */
+function resolveTrustProxy(): boolean | number | string {
+  const raw = process.env.TRUST_PROXY?.trim();
+  if (!raw) return false;
+  const lower = raw.toLowerCase();
+  if (lower === 'false' || lower === 'off' || lower === '0') return false;
+  if (lower === 'true' || lower === 'on') return true;
+  const n = Number(raw);
+  if (Number.isInteger(n) && n >= 0) return n;
+  return raw;
+}
+
 export const config: RuntimeConfig = {
   port: Number(process.env.PORT ?? 8787),
   host: process.env.HOST ?? '0.0.0.0',
@@ -29,6 +57,7 @@ export const config: RuntimeConfig = {
   allowedRoots: resolveRoots(),
   initialPassword: process.env.WEBOBSIDIAN_PASSWORD || undefined,
   isProd: process.env.NODE_ENV === 'production',
+  trustProxy: resolveTrustProxy(),
 };
 
 export const SETTINGS_FILE = path.join(config.dataDir, 'settings.json');

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -50,7 +50,11 @@ async function main() {
   await ensureVault();
 
   const app = express();
-  app.set('trust proxy', 1);
+  // Only honour X-Forwarded-* when explicitly configured for the deployment's
+  // proxy topology (TRUST_PROXY). Default false: a directly-exposed instance must
+  // NOT trust client-supplied X-Forwarded-For, or attackers could spoof it to get
+  // a fresh login rate-limit bucket per request (security report F-03).
+  app.set('trust proxy', config.trustProxy);
   app.use(express.json({ limit: '32mb' }));
   app.use(cookieParser());
 

--- a/server/src/middleware/ratelimit.ts
+++ b/server/src/middleware/ratelimit.ts
@@ -11,8 +11,12 @@ const MAX_ATTEMPTS = 10; // per window per IP
 const attempts = new Map<string, number[]>();
 
 function clientIp(req: Request): string {
-  // `trust proxy` is set, so req.ip honours X-Forwarded-For from the trusted proxy.
-  return req.ip || req.socket.remoteAddress || 'unknown';
+  // Key on the real TCP peer address, NOT req.ip. req.ip derives from
+  // X-Forwarded-For when `trust proxy` is enabled, which a directly-connected
+  // attacker can spoof per request to get a fresh bucket and bypass the limit
+  // (security report F-03). The socket address can't be forged at this layer,
+  // so the throttle holds regardless of how `trust proxy` is configured.
+  return req.socket.remoteAddress || 'unknown';
 }
 
 export function loginRateLimit(req: Request, res: Response, next: NextFunction): void {


### PR DESCRIPTION
<!-- Thanks for contributing to WebObsidian! -->

## Summary

- **Phân loại:** OWASP A05 Security Misconfiguration (+ A07).
- `app.set('trust proxy', 1)` được bật cố định ⇒ `req.ip` lấy từ `X-Forwarded-For` do
  client gửi. Rate-limiter `/auth/login` khóa theo `req.ip`, nên attacker chỉ cần xoay
  vòng header `X-Forwarded-For` mỗi request là có một bucket mới ⇒ **vượt giới hạn
  10 lần/15 phút và brute-force mật khẩu không giới hạn
- **Kết quả kiểm chứng (report):** cùng IP → có `429` từ lần 11; xoay vòng XFF 20 request
  → không có `429` nào (bypass hoàn toàn).


## Related
## F-03 — Bypass rate-limit đăng nhập qua header `X-Forwarded-For`

- **OWASP:** A05 Security Misconfiguration (+ A07).
- **Mức độ:** Cao (kết hợp F-01/F-05).
- **Vị trí:** `server/src/index.ts:53` (`app.set('trust proxy', 1)`),
  `server/src/middleware/ratelimit.ts:13-16` (key theo `req.ip`).
- **Mô tả:** `trust proxy: 1` luôn bật ⇒ `req.ip` lấy từ `X-Forwarded-For`. Khi instance lộ trực
  tiếp (không có reverse proxy thật — mà bind mặc định `0.0.0.0` cho phép, xem F-05), attacker tự
  đặt `X-Forwarded-For` mỗi request ⇒ mỗi "IP" có bucket riêng ⇒ vượt giới hạn 10 lần/15 phút.

### POC

**Chứng minh limiter có hoạt động (cùng IP giả → bị chặn ở lần 11):** gửi lặp request dưới đây
với **cùng** `X-Forwarded-For: 1.1.1.1`:
```http
POST /auth/login HTTP/1.1
Host: {{HOST}}
Content-Type: application/json
X-Forwarded-For: 1.1.1.1
Content-Length: 26

{"password":"wrong-guess"}
```
→ lần 1-10 = `401`, lần 11+ = `429 Too Many Login Attempts`.

**Bypass (Burp Intruder):** dùng cùng request nhưng biến `X-Forwarded-For` thành payload xoay vòng:
```http
POST /auth/login HTTP/1.1
Host: {{HOST}}
Content-Type: application/json
X-Forwarded-For: §9.9.0.1§
Content-Length: 26

{"password":"wrong-guess"}
```
Intruder → Payload type **Numbers** (hoặc danh sách IP) → chạy 20+ request.

- **Kết quả thực nghiệm:** cùng IP → có `429` từ lần 11; xoay vòng XFF 20 request → **không có
  `429` nào** (bypass hoàn toàn).
- **Tác động:** Brute-force mật khẩu không giới hạn (đặc biệt nguy hiểm với pass mặc định 6 ký tự).
- **Khắc phục đề xuất:** Cấu hình `trust proxy` đúng theo hạ tầng (vd chỉ tin IP của reverse proxy,
  hoặc `false` khi không có proxy); thêm giới hạn toàn cục theo socket address; làm chậm xác thực.


## Type of change

- [x ] Bug fix

## Checklist

- [x ] `npm run typecheck` passes
- [ x] `npm run build` succeeds
- [ x] Updated [PRD.md](../PRD.md) if design/scope changed (with changelog bump)
- [ x] Updated [IMPLEMENTATION_PLAN.md](../IMPLEMENTATION_PLAN.md) checkboxes + progress log
- [ x] No secrets/tokens logged; paths guarded against traversal