### PR TITLE
fix(canvas): drop unsafe URL schemes on shared canvas link nodes

### DIFF
--- a/server/src/services/rendercanvas.ts
+++ b/server/src/services/rendercanvas.ts
@@ -44,6 +44,12 @@ function num(v: unknown, fallback = 0): number {
   return Number.isFinite(n) ? n : fallback;
 }
 
+/** Only allow safe URL schemes for hrefs taken from untrusted .canvas link nodes.
+ *  CSP blocks javascript: execution, but drop the scheme rather than render it. */
+function safeHref(url: string): string {
+  return /^(?:https?:|mailto:)/i.test(url.trim()) ? url.trim() : '';
+}
+
 function sideAnchor(n: Rect, side: Side): { x: number; y: number } {
   switch (side) {
     case 'top': return { x: n.x + n.width / 2, y: n.y };
@@ -103,7 +109,7 @@ async function renderNode(n: CNode, fileUrl: (p: string) => string): Promise<str
   }
   if (n.type === 'link') {
     const url = n.url ?? '';
-    return `<div class="canvas-node canvas-link" style="${style}"><a class="canvas-link-body" href="${escapeHtml(url)}" target="_blank" rel="noopener nofollow"><span class="url">${escapeHtml(url)}</span></a></div>`;
+    return `<div class="canvas-node canvas-link" style="${style}"><a class="canvas-link-body" href="${escapeHtml(safeHref(url))}" target="_blank" rel="noopener nofollow"><span class="url">${escapeHtml(url)}</span></a></div>`;
   }
   // file node
   const file = n.file ?? '';


### PR DESCRIPTION
Tiny hardening follow-up to the canvas work in 46d3804.

Canvas **link** nodes still render `href="${escapeHtml(url)}"` with no scheme check, so a `javascript:` URL in a shared `.canvas` survives onto the public `/share/:id` page. CSP blocks execution (so this is low severity), but it's better to drop it than render it.

`safeHref()` restricts link hrefs to `http(s)`/`mailto`; the visible URL text is unchanged. (Geometry coercion via `num()` and the `textAlign` whitelist from 46d3804 already cover the other canvas vectors — this is just the link href.)

No behavior change for legitimate links.
