### PR TITLE
test: real-git integration (init/commit/status/log/sync)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
-        "electron": "^33.2.1",
+        "electron": "33.4.11",
         "electron-builder": "^25.1.8",
         "esbuild": "^0.24.0"
       }
@@ -3667,6 +3667,119 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@webgpu/types": {
       "version": "0.1.70",
       "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.70.tgz",
@@ -4093,6 +4206,16 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -4514,6 +4637,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/cacache": {
       "version": "16.1.3",
       "resolved": "https://registry.npmjs.org/cacache/-/cacache-16.1.3.tgz",
@@ -4694,6 +4827,23 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -4752,6 +4902,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chownr": {
@@ -5840,6 +6000,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/defaults": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
@@ -6570,6 +6740,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
@@ -6699,6 +6876,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -6713,6 +6900,16 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/exponential-backoff": {
       "version": "3.1.3",
@@ -8392,6 +8589,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lowercase-keys": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
@@ -8410,6 +8614,16 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/make-fetch-happen": {
@@ -10075,6 +10289,23 @@
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/pe-library": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/pe-library/-/pe-library-0.4.1.tgz",
@@ -11051,6 +11282,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -11231,6 +11469,13 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stat-mode": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
@@ -11249,6 +11494,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/streamsearch": {
       "version": "1.1.0",
@@ -11501,6 +11753,13 @@
         "node": ">=12"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
@@ -11508,6 +11767,36 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tmp": {
@@ -12015,6 +12304,29 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
@@ -12445,6 +12757,79 @@
         "@esbuild/win32-x64": "0.21.5"
       }
     },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/w3c-keyname": {
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
@@ -12485,6 +12870,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wide-align": {
@@ -12762,7 +13164,8 @@
         "@types/node": "^22.9.0",
         "@types/ws": "^8.5.13",
         "tsx": "^4.19.2",
-        "typescript": "^5.6.3"
+        "typescript": "^5.6.3",
+        "vitest": "^2.1.9"
       }
     },
     "server/node_modules/chokidar": {

--- a/server/package.json
+++ b/server/package.json
@@ -8,7 +8,9 @@
     "dev": "tsx watch src/index.ts",
     "build": "tsc -p tsconfig.json",
     "start": "node dist/index.js",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "chokidar": "^3.6.0",
@@ -40,6 +42,7 @@
     "@types/node": "^22.9.0",
     "@types/ws": "^8.5.13",
     "tsx": "^4.19.2",
-    "typescript": "^5.6.3"
+    "typescript": "^5.6.3",
+    "vitest": "^2.1.9"
   }
 }

--- a/server/src/lib/redact.test.ts
+++ b/server/src/lib/redact.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { redactUrlCreds } from './redact.js';
+
+describe('redactUrlCreds', () => {
+  it('strips a PAT from an https remote', () => {
+    expect(redactUrlCreds('https://ghp_TOKEN123@github.com/o/r.git')).toBe(
+      'https://***@github.com/o/r.git',
+    );
+  });
+
+  it('strips user:pass userinfo', () => {
+    expect(redactUrlCreds('https://user:pass@host/x')).toBe('https://***@host/x');
+  });
+
+  it('redacts a userinfo on any scheme (e.g. ssh://)', () => {
+    expect(redactUrlCreds('ssh://git@host/x')).toBe('ssh://***@host/x');
+  });
+
+  it('leaves scp-style git@host:path untouched (no scheme://)', () => {
+    expect(redactUrlCreds('git@github.com:o/r.git')).toBe('git@github.com:o/r.git');
+  });
+
+  it('redacts every credentialed URL in a longer string (global)', () => {
+    const input = 'fatal: https://a@x.com/1 and https://b@y.com/2 failed';
+    expect(redactUrlCreds(input)).toBe('fatal: https://***@x.com/1 and https://***@y.com/2 failed');
+  });
+
+  it('leaves text with no credentialed URL unchanged', () => {
+    expect(redactUrlCreds('nothing to see here')).toBe('nothing to see here');
+    expect(redactUrlCreds('https://github.com/o/r.git')).toBe('https://github.com/o/r.git');
+  });
+
+  it('coerces non-string input (undefined -> empty, Error message redacted)', () => {
+    expect(redactUrlCreds(undefined)).toBe('');
+    expect(redactUrlCreds(null)).toBe('');
+    const err = new Error('clone failed: https://tok@github.com/o/r.git');
+    expect(redactUrlCreds(err.message)).toBe('clone failed: https://***@github.com/o/r.git');
+  });
+});

--- a/server/src/routes/settings.test.ts
+++ b/server/src/routes/settings.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Isolate the import chain — we only exercise the pure isWithinRoots predicate.
+vi.mock('../services/settings.js', () => ({
+  getSettings: vi.fn(),
+  updateSettings: vi.fn(),
+  redactSettings: vi.fn(),
+  ensureVaultBrowsable: vi.fn(),
+}));
+
+import { isWithinRoots } from './settings.js';
+
+describe('isWithinRoots — vault-path authorization boundary', () => {
+  it('allows a path inside an allowed root', () => {
+    expect(isWithinRoots('/vault/notes/a.md', ['/vault'])).toBe(true);
+  });
+
+  it('allows the root itself', () => {
+    expect(isWithinRoots('/vault', ['/vault'])).toBe(true);
+  });
+
+  it('rejects escaping above the root (the {"path":"/","allowedRoots":["/"]} attack)', () => {
+    expect(isWithinRoots('/', ['/vault'])).toBe(false);
+    expect(isWithinRoots('/etc/passwd', ['/vault'])).toBe(false);
+  });
+
+  it('rejects a sibling that merely shares a name prefix', () => {
+    expect(isWithinRoots('/vault-evil', ['/vault'])).toBe(false);
+  });
+
+  it('rejects traversal that resolves outside the root', () => {
+    expect(isWithinRoots('/vault/../etc', ['/vault'])).toBe(false);
+  });
+
+  it('honours multiple roots', () => {
+    expect(isWithinRoots('/data/x', ['/vault', '/data'])).toBe(true);
+  });
+});

--- a/server/src/routes/settings.ts
+++ b/server/src/routes/settings.ts
@@ -65,27 +65,31 @@ function sanitizeVault(v: any) {
   return out;
 }
 
-/** The roots a new vault path may live under — mirrors GET /browse. */
-async function effectiveRoots(newAllowed?: unknown): Promise<string[]> {
-  const s = await getSettings();
-  const fromBody = Array.isArray(newAllowed)
-    ? (newAllowed as unknown[]).filter((r): r is string => typeof r === 'string')
-    : [];
-  const roots = fromBody.length
-    ? fromBody
-    : s.vault.allowedRoots.length
-      ? s.vault.allowedRoots
-      : config.allowedRoots.length
-        ? config.allowedRoots
-        : [os.homedir()];
+/**
+ * The hard boundary for where the vault may live. Comes ONLY from operator-
+ * controlled configuration — the env ALLOWED_ROOTS, else the home directory — and
+ * NEVER from the request body or from mutable settings. Otherwise the new path was
+ * validated against `allowedRoots` taken from the same request, so a request could
+ * authorize its own path (e.g. {"path":"/","allowedRoots":["/"]}) and repoint the
+ * whole files API at the host filesystem.
+ */
+function authorizedRoots(): string[] {
+  const roots = config.allowedRoots.length ? config.allowedRoots : [os.homedir()];
   return roots.map((r) => path.resolve(r));
 }
 
-async function assertVaultPathAllowed(v: any): Promise<void> {
+/** True iff `target` resolves to, or inside, one of `roots`. */
+export function isWithinRoots(target: string, roots: string[]): boolean {
+  const t = path.resolve(target);
+  return roots.some((r) => {
+    const rr = path.resolve(r);
+    return t === rr || t.startsWith(rr + path.sep);
+  });
+}
+
+async function assertVaultPathAllowed(v: { path: unknown }): Promise<void> {
   const target = path.resolve(String(v.path));
-  const roots = await effectiveRoots(v.allowedRoots);
-  const within = roots.some((r) => target === r || target.startsWith(r + path.sep));
-  if (!within) {
+  if (!isWithinRoots(target, authorizedRoots())) {
     throw Object.assign(new Error('Vault path is outside the allowed roots'), { status: 403 });
   }
   const st = await fs.stat(target).catch(() => null);
@@ -99,19 +103,11 @@ async function assertVaultPathAllowed(v: any): Promise<void> {
 settingsRouter.get(
   '/browse',
   asyncHandler(async (req, res) => {
-    const s = await getSettings();
-    const roots = s.vault.allowedRoots.length
-      ? s.vault.allowedRoots
-      : config.allowedRoots.length
-        ? config.allowedRoots
-        : [os.homedir()];
+    // Bound the picker to the same hard roots that authorize a vault path — never
+    // to mutable settings, which a prior request could have widened.
+    const roots = authorizedRoots();
     const dir = req.query.dir ? path.resolve(String(req.query.dir)) : roots[0];
-
-    const allowed = roots.some((r) => {
-      const rr = path.resolve(r);
-      return dir === rr || dir.startsWith(rr + path.sep);
-    });
-    if (!allowed) {
+    if (!isWithinRoots(dir, roots)) {
       res.status(403).json({ error: 'Path outside allowed roots', roots });
       return;
     }

--- a/server/src/services/autosync.test.ts
+++ b/server/src/services/autosync.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const { settings, syncMock } = vi.hoisted(() => ({
+  settings: { git: { enabled: true, autoSync: true, remote: 'https://x', intervalSec: 60 } },
+  syncMock: vi.fn(async () => ({ ok: true, log: [] as string[] })),
+}));
+vi.mock('./settings.js', () => ({ getSettings: vi.fn(async () => settings) }));
+vi.mock('./git.js', () => ({ sync: syncMock }));
+
+let startAutoSync: () => void;
+
+beforeEach(async () => {
+  settings.git.enabled = true;
+  settings.git.autoSync = true;
+  settings.git.remote = 'https://x';
+  settings.git.intervalSec = 60;
+  syncMock.mockReset();
+  syncMock.mockResolvedValue({ ok: true, log: [] });
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+  // Reset module-private lastRun/running/timer between tests.
+  vi.resetModules();
+  ({ startAutoSync } = await import('./autosync.js'));
+});
+afterEach(() => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
+});
+
+describe('autosync tick — gating', () => {
+  it('does not sync when git is disabled', async () => {
+    settings.git.enabled = false;
+    startAutoSync();
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(syncMock).not.toHaveBeenCalled();
+  });
+
+  it('does not sync when autoSync is off', async () => {
+    settings.git.autoSync = false;
+    startAutoSync();
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(syncMock).not.toHaveBeenCalled();
+  });
+
+  it('does not sync when no remote is configured', async () => {
+    settings.git.remote = '';
+    startAutoSync();
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(syncMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('autosync tick — interval rate limit', () => {
+  it('syncs on the first tick, then waits out intervalSec before the next', async () => {
+    startAutoSync();
+    await vi.advanceTimersByTimeAsync(30_000); // tick @30s → first sync
+    expect(syncMock).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(30_000); // tick @60s → only 30s since last → skip
+    expect(syncMock).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(30_000); // tick @90s → 60s since last → sync
+    expect(syncMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('autosync tick — reentrancy guard', () => {
+  it('does not start a second sync while one is still in flight', async () => {
+    let resolveSync: (v: unknown) => void = () => {};
+    syncMock.mockImplementation(() => new Promise((res) => { resolveSync = res; }));
+
+    startAutoSync();
+    await vi.advanceTimersByTimeAsync(30_000); // tick 1 → sync starts, stays pending
+    expect(syncMock).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(30_000); // tick 2 → blocked by `running`
+    expect(syncMock).toHaveBeenCalledTimes(1);
+
+    resolveSync({ ok: true, log: [] }); // first sync completes, guard releases
+    await vi.advanceTimersByTimeAsync(120_000); // flush + advance past the interval
+    expect(syncMock.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/server/src/services/git.integration.test.ts
+++ b/server/src/services/git.integration.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach, afterEach, beforeAll, afterAll } from 'vitest';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const exec = promisify(execFile);
+const T = 20_000; // generous per-test timeout — these shell out to real git
+
+// Full git settings; vault.path is set per test to a fresh temp repo.
+const { settings } = vi.hoisted(() => ({
+  settings: {
+    vault: { path: '', trash: '.trash' },
+    git: {
+      enabled: true,
+      autoSync: false,
+      autoCommitOnSave: false,
+      remote: '',
+      token: '',
+      branch: 'main',
+      authorName: 'Tester',
+      authorEmail: 'tester@example.com',
+      lfsPatterns: [] as string[],
+      intervalSec: 60,
+    },
+  },
+}));
+vi.mock('./settings.js', () => ({ getSettings: vi.fn(async () => settings) }));
+
+const git = await import('./git.js');
+
+const gitOnPath = await exec('git', ['--version']).then(() => true).catch(() => false);
+
+// Isolate from the developer's ~/.gitconfig: pin the default branch + a fallback
+// identity + non-interactive merges for every git process this suite spawns.
+let cfgHome: string;
+let prevGlobal: string | undefined;
+let prevAutoEdit: string | undefined;
+beforeAll(async () => {
+  cfgHome = await fs.mkdtemp(path.join(os.tmpdir(), 'wo-gitcfg-'));
+  const cfg = path.join(cfgHome, 'gitconfig');
+  await fs.writeFile(
+    cfg,
+    '[init]\n  defaultBranch = main\n[user]\n  name = CI\n  email = ci@example.com\n',
+  );
+  prevGlobal = process.env.GIT_CONFIG_GLOBAL;
+  prevAutoEdit = process.env.GIT_MERGE_AUTOEDIT;
+  process.env.GIT_CONFIG_GLOBAL = cfg;
+  process.env.GIT_MERGE_AUTOEDIT = 'no';
+});
+afterAll(async () => {
+  if (prevGlobal === undefined) delete process.env.GIT_CONFIG_GLOBAL;
+  else process.env.GIT_CONFIG_GLOBAL = prevGlobal;
+  if (prevAutoEdit === undefined) delete process.env.GIT_MERGE_AUTOEDIT;
+  else process.env.GIT_MERGE_AUTOEDIT = prevAutoEdit;
+  await fs.rm(cfgHome, { recursive: true, force: true });
+});
+
+let work: string;
+let bare: string;
+beforeEach(async () => {
+  work = await fs.mkdtemp(path.join(os.tmpdir(), 'wo-gitwork-'));
+  bare = await fs.mkdtemp(path.join(os.tmpdir(), 'wo-gitbare-'));
+  await exec('git', ['init', '--bare', '-b', 'main', bare]);
+  settings.vault.path = work;
+  Object.assign(settings.git, {
+    enabled: true,
+    remote: bare,
+    token: '',
+    branch: 'main',
+    authorName: 'Tester',
+    authorEmail: 'tester@example.com',
+    lfsPatterns: [],
+  });
+});
+afterEach(async () => {
+  await fs.rm(work, { recursive: true, force: true });
+  await fs.rm(bare, { recursive: true, force: true });
+});
+
+describe.skipIf(!gitOnPath)('git integration (real repo)', () => {
+  it(
+    'init creates a repo, configures identity, and sets origin',
+    async () => {
+      await git.init();
+      const { stdout: origin } = await exec('git', ['-C', work, 'remote', 'get-url', 'origin']);
+      expect(origin.trim()).toBe(bare);
+      const { stdout: name } = await exec('git', ['-C', work, 'config', 'user.name']);
+      expect(name.trim()).toBe('Tester');
+    },
+    T,
+  );
+
+  it(
+    'authedRemote injects the PAT into an https origin (no network)',
+    async () => {
+      settings.git.remote = 'https://github.com/o/r.git';
+      settings.git.token = 'ghp_SECRET';
+      await git.init();
+      const { stdout } = await exec('git', ['-C', work, 'remote', 'get-url', 'origin']);
+      expect(stdout.trim()).toBe('https://ghp_SECRET@github.com/o/r.git');
+    },
+    T,
+  );
+
+  it(
+    'commitAll stages everything; subject = describeChanges and body lists the file',
+    async () => {
+      await git.init();
+      await fs.writeFile(path.join(work, 'Hello.md'), '# Hi');
+      const res = await git.commitAll();
+      expect(res).toContain('Add Hello');
+      const { stdout: body } = await exec('git', ['-C', work, 'log', '-1', '--pretty=%B']);
+      expect(body).toContain('Add Hello'); // subject
+      expect(body).toContain('Hello.md'); // body file list
+    },
+    T,
+  );
+
+  it(
+    'status maps repo state (clean -> notAdded -> clean)',
+    async () => {
+      await git.init();
+      expect((await git.status()).isRepo).toBe(true);
+      expect((await git.status()).clean).toBe(true);
+
+      await fs.writeFile(path.join(work, 'a.md'), 'x');
+      const dirty = await git.status();
+      expect(dirty.notAdded).toBe(1);
+      expect(dirty.clean).toBe(false);
+
+      await git.commitAll();
+      expect((await git.status()).clean).toBe(true);
+    },
+    T,
+  );
+
+  it(
+    'log + showFile round-trip a committed file',
+    async () => {
+      await git.init();
+      await fs.writeFile(path.join(work, 'note.md'), 'v1');
+      await git.commitAll();
+      const commits = await git.log('note.md');
+      expect(commits).toHaveLength(1);
+      expect(await git.showFile(commits[0].hash, 'note.md')).toBe('v1');
+    },
+    T,
+  );
+
+  it(
+    'sync pushes to the bare remote and merges a peer change (no conflict)',
+    async () => {
+      // device 1: init + commit + sync (push to bare)
+      await git.init();
+      await fs.writeFile(path.join(work, 'a.md'), 'A');
+      expect((await git.sync()).ok).toBe(true);
+
+      // a peer clones the bare, adds b.md, pushes
+      const peer = await fs.mkdtemp(path.join(os.tmpdir(), 'wo-peer-'));
+      try {
+        await exec('git', ['clone', '-b', 'main', bare, peer]);
+        expect(await fs.readFile(path.join(peer, 'a.md'), 'utf8')).toBe('A');
+        await fs.writeFile(path.join(peer, 'b.md'), 'B');
+        await exec('git', ['-C', peer, 'add', '.']);
+        await exec('git', ['-C', peer, 'commit', '-m', 'peer adds b']);
+        await exec('git', ['-C', peer, 'push', 'origin', 'main']);
+
+        // device 1: add c.md, sync -> pulls b, merges, pushes c
+        await fs.writeFile(path.join(work, 'c.md'), 'C');
+        expect((await git.sync()).ok).toBe(true);
+        expect(await fs.readFile(path.join(work, 'b.md'), 'utf8')).toBe('B');
+        expect(await fs.readFile(path.join(work, 'c.md'), 'utf8')).toBe('C');
+      } finally {
+        await fs.rm(peer, { recursive: true, force: true });
+      }
+    },
+    T,
+  );
+});

--- a/server/src/services/git.test.ts
+++ b/server/src/services/git.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const { settings, getSettingsMock } = vi.hoisted(() => {
+  const settings = { git: { enabled: true, autoCommitOnSave: false, remote: '' } };
+  return { settings, getSettingsMock: vi.fn(async () => settings) };
+});
+vi.mock('./settings.js', () => ({ getSettings: getSettingsMock, updateSettings: vi.fn() }));
+
+const { describeChanges, scheduleAutoCommitOnSave } = await import('./git.js');
+
+/** Minimal StatusResult-like object — describeChanges only reads `.files`. */
+const status = (files: Array<{ path: string; index?: string; working_dir?: string }>) =>
+  ({ files }) as any;
+
+describe('describeChanges', () => {
+  it('returns "Vault sync" with empty body for no changes', () => {
+    expect(describeChanges(status([]))).toEqual({ subject: 'Vault sync', body: '' });
+  });
+
+  it('names a single added note (basename, .md stripped)', () => {
+    const r = describeChanges(status([{ path: 'Notes/Hello.md', index: 'A' }]));
+    expect(r.subject).toBe('Add Hello');
+    expect(r.body).toBe('Added (1):\n  Notes/Hello.md');
+  });
+
+  it('treats an untracked (?) file as added', () => {
+    expect(describeChanges(status([{ path: 'New.md', index: '?', working_dir: '?' }])).subject).toBe(
+      'Add New',
+    );
+  });
+
+  it('uses the right verb for delete / rename / modify', () => {
+    expect(describeChanges(status([{ path: 'Old.md', index: 'D' }])).subject).toBe('Delete Old');
+    expect(describeChanges(status([{ path: 'R.md', index: 'R' }])).subject).toBe('Rename R');
+    expect(describeChanges(status([{ path: 'M.md', index: 'M' }])).subject).toBe('Update M');
+  });
+
+  it('summarizes mixed changes with counts and the first three names', () => {
+    const r = describeChanges(
+      status([
+        { path: 'a1.md', index: 'A' },
+        { path: 'a2.md', index: 'A' },
+        { path: 'm1.md', index: 'M' },
+        { path: 'd1.md', index: 'D' },
+      ]),
+    );
+    expect(r.subject).toBe('Sync 4 notes (2 new, 1 edited, 1 deleted): a1, a2, m1 +1 more');
+    expect(r.body).toContain('Added (2):');
+    expect(r.body).toContain('Modified (1):');
+    expect(r.body).toContain('Deleted (1):');
+  });
+
+  it('caps the subject at 72 chars with an ellipsis', () => {
+    const r = describeChanges(status([{ path: 'x'.repeat(80) + '.md', index: 'A' }]));
+    expect(r.subject.length).toBe(72);
+    expect(r.subject.endsWith('…')).toBe(true);
+    expect(r.subject.startsWith('Add x')).toBe(true);
+  });
+
+  it('caps the body file list at 100 with an "…and N more" line', () => {
+    const files = Array.from({ length: 101 }, (_, i) => ({ path: `n${i}.md`, index: 'A' }));
+    const r = describeChanges(status(files));
+    expect(r.body).toContain('Added (101):');
+    expect(r.body).toContain('…and 1 more');
+  });
+});
+
+describe('scheduleAutoCommitOnSave (5s debounce)', () => {
+  // Observable: the callback always awaits getSettings() first. With
+  // autoCommitOnSave=false it short-circuits before touching the same-module
+  // sync()/commitAll() (which can't run without real git), so getSettings call
+  // count is a clean proxy for "the debounced callback fired".
+  beforeEach(() => {
+    settings.git.enabled = true;
+    settings.git.autoCommitOnSave = false;
+    settings.git.remote = '';
+    getSettingsMock.mockClear();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+  });
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('does not fire before 5s', async () => {
+    scheduleAutoCommitOnSave();
+    await vi.advanceTimersByTimeAsync(4999);
+    expect(getSettingsMock).not.toHaveBeenCalled();
+  });
+
+  it('fires once at 5s', async () => {
+    scheduleAutoCommitOnSave();
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(getSettingsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('coalesces rapid calls into a single fire', async () => {
+    scheduleAutoCommitOnSave();
+    scheduleAutoCommitOnSave();
+    scheduleAutoCommitOnSave();
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(getSettingsMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/src/services/vault.test.ts
+++ b/server/src/services/vault.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// Vault writes are real fs; redirect the root at a throwaway temp dir per test.
+const { settings } = vi.hoisted(() => ({
+  settings: { vault: { path: '', trash: '.trash' } },
+}));
+vi.mock('./settings.js', () => ({ getSettings: vi.fn(async () => settings) }));
+
+const vault = await import('./vault.js');
+
+let root: string;
+beforeEach(async () => {
+  root = await fs.mkdtemp(path.join(os.tmpdir(), 'wo-vault-'));
+  settings.vault.path = root;
+  settings.vault.trash = '.trash';
+});
+afterEach(async () => {
+  await fs.rm(root, { recursive: true, force: true });
+});
+
+const abs = (rel: string) => path.join(root, rel);
+
+describe('vault writes', () => {
+  it('writeFileText round-trips content and creates nested parent dirs', async () => {
+    await vault.writeFileText('a/b/c.md', '# Hello');
+    expect(await vault.readFileText('a/b/c.md')).toBe('# Hello');
+    expect(await fs.readFile(abs('a/b/c.md'), 'utf8')).toBe('# Hello');
+  });
+
+  it('writeFileText overwrites and leaves no stray tmp file', async () => {
+    await vault.writeFileText('note.md', 'first');
+    await vault.writeFileText('note.md', 'second');
+    expect(await vault.readFileText('note.md')).toBe('second');
+    const entries = await fs.readdir(root);
+    expect(entries.filter((e) => e.includes('tmp'))).toHaveLength(0);
+  });
+
+  it('writeFileBuffer writes byte-equal binary', async () => {
+    const buf = Buffer.from([0, 1, 2, 254, 255]);
+    await vault.writeFileBuffer('img/x.bin', buf);
+    expect(await fs.readFile(abs('img/x.bin'))).toEqual(buf);
+  });
+
+  it('createFolder makes a directory', async () => {
+    await vault.createFolder('sub/dir');
+    expect((await fs.stat(abs('sub/dir'))).isDirectory()).toBe(true);
+  });
+
+  it('rename moves a file and creates the destination parent', async () => {
+    await vault.writeFileText('old.md', 'x');
+    await vault.rename('old.md', 'moved/new.md');
+    expect(await vault.exists('old.md')).toBe(false);
+    expect(await vault.readFileText('moved/new.md')).toBe('x');
+  });
+
+  it('remove permanently deletes a file and a folder recursively', async () => {
+    await vault.writeFileText('f.md', 'x');
+    await vault.remove('f.md');
+    expect(await vault.exists('f.md')).toBe(false);
+
+    await vault.writeFileText('d/one.md', '1');
+    await vault.writeFileText('d/two.md', '2');
+    await vault.remove('d');
+    expect(await vault.exists('d')).toBe(false);
+  });
+});
+
+describe('vault copy', () => {
+  it('returns the vault-relative posix paths of every file created', async () => {
+    await vault.writeFileText('src/a.md', 'a');
+    await vault.writeFileText('src/sub/b.md', 'b');
+    const created = await vault.copy('src', 'dst');
+    expect([...created].sort()).toEqual(['dst/a.md', 'dst/sub/b.md']);
+    expect(await vault.readFileText('dst/sub/b.md')).toBe('b');
+  });
+
+  it('returns a single path for a file copy', async () => {
+    await vault.writeFileText('one.md', '1');
+    expect(await vault.copy('one.md', 'two.md')).toEqual(['two.md']);
+  });
+
+  it('rejects when the destination already exists', async () => {
+    await vault.writeFileText('a.md', 'a');
+    await vault.writeFileText('b.md', 'b');
+    await expect(vault.copy('a.md', 'b.md')).rejects.toBeTruthy();
+  });
+});
+
+describe('resolveDirCaseInsensitive', () => {
+  it('matches an existing folder case-insensitively', async () => {
+    await vault.createFolder('Attachments');
+    expect(await vault.resolveDirCaseInsensitive('attachments')).toBe('Attachments');
+  });
+
+  it('matches existing segments and keeps new ones verbatim', async () => {
+    await vault.createFolder('Attachments');
+    expect(await vault.resolveDirCaseInsensitive('attachments/New')).toBe('Attachments/New');
+  });
+
+  it('returns a fully-new path unchanged', async () => {
+    expect(await vault.resolveDirCaseInsensitive('Brand/New')).toBe('Brand/New');
+  });
+});
+
+describe('path safety (resolveInVault)', () => {
+  it('rejects ../ traversal', async () => {
+    await expect(vault.resolveInVault('../escape.md')).rejects.toMatchObject({ status: 400 });
+  });
+
+  it('clamps an absolute path under the vault root (leading slash stripped, not honored)', async () => {
+    const resolved = await vault.resolveInVault('/etc/passwd');
+    expect(resolved.startsWith(root + path.sep)).toBe(true);
+    expect(resolved).toContain(`etc${path.sep}passwd`);
+  });
+
+  it('blocks the .git segment', async () => {
+    await expect(vault.resolveInVault('.git/config')).rejects.toMatchObject({ status: 400 });
+    await expect(vault.resolveInVault('sub/.git/hooks/post-merge')).rejects.toMatchObject({
+      status: 400,
+    });
+  });
+
+  it('allows .gitignore / .gitattributes (only the exact .git segment is blocked)', async () => {
+    await expect(vault.resolveInVault('.gitignore')).resolves.toContain('.gitignore');
+    await expect(vault.resolveInVault('.gitattributes')).resolves.toContain('.gitattributes');
+  });
+
+  it('guards the mutation path too (writeFileText cannot escape)', async () => {
+    await expect(vault.writeFileText('../evil.md', 'x')).rejects.toMatchObject({ status: 400 });
+  });
+
+  it.skipIf(process.platform === 'win32')(
+    'rejects a symlink that escapes the vault',
+    async () => {
+      const outside = await fs.mkdtemp(path.join(os.tmpdir(), 'wo-outside-'));
+      try {
+        await fs.writeFile(path.join(outside, 'secret.md'), 'top secret');
+        await fs.symlink(outside, abs('link'), 'dir');
+        await expect(vault.resolveInVault('link/secret.md')).rejects.toMatchObject({ status: 400 });
+        await expect(vault.writeFileText('link/secret.md', 'x')).rejects.toMatchObject({
+          status: 400,
+        });
+      } finally {
+        await fs.rm(outside, { recursive: true, force: true });
+      }
+    },
+  );
+});
+
+describe('trash round-trip', () => {
+  it('moves a file to trash and restores it, pruning empty dirs', async () => {
+    await vault.writeFileText('notes/a.md', 'hello');
+    const trashed = await vault.trash('notes/a.md');
+    expect(trashed).toBe('.trash/notes/a.md');
+    expect(await vault.exists('notes/a.md')).toBe(false);
+
+    const items = await vault.listTrash();
+    expect(items).toHaveLength(1);
+    expect(items[0].original).toBe('notes/a.md');
+
+    const restored = await vault.restoreFromTrash(trashed);
+    expect(restored).toBe('notes/a.md');
+    expect(await vault.readFileText('notes/a.md')).toBe('hello');
+    expect(await vault.listTrash()).toHaveLength(0);
+    // the now-empty .trash/notes dir was pruned
+    expect(await vault.exists('.trash/notes')).toBe(false);
+  });
+
+  it('adds a timestamp suffix when a file is trashed twice', async () => {
+    await vault.writeFileText('a.md', '1');
+    await vault.trash('a.md');
+    await vault.writeFileText('a.md', '2');
+    const second = await vault.trash('a.md');
+    expect(second).toMatch(/^\.trash\/a\.\d+\.md$/);
+    expect(await vault.listTrash()).toHaveLength(2);
+  });
+
+  it('adds a .restored- suffix when the original path was recreated', async () => {
+    await vault.writeFileText('a.md', 'orig');
+    const trashed = await vault.trash('a.md');
+    await vault.writeFileText('a.md', 'recreated');
+    const restored = await vault.restoreFromTrash(trashed);
+    expect(restored).toMatch(/^a\.restored-\d+\.md$/);
+    expect(await vault.exists('a.md')).toBe(true);
+    expect(await vault.exists(restored)).toBe(true);
+  });
+
+  it('deleteFromTrash removes one item and rejects a non-trash path', async () => {
+    await vault.writeFileText('a.md', 'x');
+    const trashed = await vault.trash('a.md');
+    await vault.deleteFromTrash(trashed);
+    expect(await vault.listTrash()).toHaveLength(0);
+
+    await vault.writeFileText('real.md', 'x');
+    await expect(vault.deleteFromTrash('real.md')).rejects.toMatchObject({ status: 400 });
+  });
+
+  it('emptyTrash clears everything', async () => {
+    await vault.writeFileText('a.md', 'a');
+    await vault.writeFileText('b.md', 'b');
+    await vault.trash('a.md');
+    await vault.trash('b.md');
+    expect(await vault.listTrash()).toHaveLength(2);
+    await vault.emptyTrash();
+    expect(await vault.listTrash()).toHaveLength(0);
+  });
+});

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -16,5 +16,6 @@
     "lib": ["ES2022"],
     "types": ["node"]
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
Follow-up to #6 (deterministic tests) — adds **real-git integration** coverage.

`git.integration.test.ts` drives the real `git` binary (via simple-git) against a throwaway temp repo and a **local bare remote** (no network):
- **init** — creates the repo, configures identity, sets `origin`; **authedRemote** injects the PAT into an `https://` origin (verified via `git remote get-url`).
- **commitAll** — subject equals `describeChanges` output and the changed file is listed in the body.
- **status** — `clean → notAdded → clean` field mapping.
- **log + showFile** — round-trip a committed file's contents.
- **sync** — pushes to the bare remote, then pulls + merges a peer device's change (different file, no conflict).

The whole file is gated behind `describe.skipIf(!gitOnPath)` so it skips cleanly where git is absent, and it isolates from your `~/.gitconfig` via a temp `GIT_CONFIG_GLOBAL` (pins `init.defaultBranch=main`, a fallback identity, non-interactive merges). ~4.5s locally; `git-lfs` not required (guarded by `lfsAvailable()`).

> Stacked on #6 (itself stacked on #2). I'll rebase the chain onto `main` as the earlier PRs land. Deep conflict-resolution (`resolveNoiseConflicts`/`recoverMerge`) is intentionally left out — brittle to test and lower value.
