### PR TITLE
chore: translate code comments to English (contributor-friendliness)

### DIFF
--- a/server/src/bootstrap.ts
+++ b/server/src/bootstrap.ts
@@ -8,9 +8,9 @@ export async function loadSettings() {
 }
 
 /**
- * WEBOBSIDIAN_PASSWORD không còn ghi vào settings.json; nó được dùng như mật khẩu
- * override (khôi phục khi quên pass), kiểm tra trực tiếp lúc login. Mật khẩu đăng
- * nhập mặc định là 123456. Chỉ log để báo override đang bật.
+ * WEBOBSIDIAN_PASSWORD is no longer written to settings.json; it's used as an
+ * override (recovery) password, checked directly at login. The default login
+ * password is 123456. We only log here to signal the override is active.
  */
 export async function setPasswordIfInitial(): Promise<void> {
   if (config.initialPassword) {

--- a/server/src/services/settings.ts
+++ b/server/src/services/settings.ts
@@ -20,9 +20,9 @@ const SettingsSchema = z.object({
   version: z.number().default(1),
   auth: z
     .object({
-      // Mật khẩu người dùng đã đổi. Rỗng = đang dùng mật khẩu mặc định (123456).
+      // The user's chosen password. Empty = still on the default password (123456).
       userPasswordHash: z.string().default(''),
-      // Mật khẩu override để khôi phục khi quên pass (sửa tay vào file). Rỗng = không có.
+      // Recovery/override password for a forgotten password (set by hand in the file). Empty = none.
       passwordHash: z.string().default(''),
       jwtSecret: z.string().default(''),
     })
@@ -32,8 +32,8 @@ const SettingsSchema = z.object({
       path: z.string().default(''),
       allowedRoots: z.array(z.string()).default([]),
       trash: z.string().default('.trash'),
-      // Xoá file: 'trash' = chuyển vào thư mục .trash (khôi phục được);
-      // 'permanent' = xoá vĩnh viễn ngay.
+      // Delete behavior: 'trash' = move into the .trash folder (recoverable);
+      // 'permanent' = delete immediately and permanently.
       deleteMode: z.enum(['trash', 'permanent']).default('trash'),
       attachmentDir: z.string().default('attachments'),
     })
@@ -147,10 +147,10 @@ export async function loadSettings(): Promise<Settings> {
       parsed.auth.jwtSecret = randomBytes(48).toString('hex');
       dirty = true;
     }
-    // Migration: trước đây `passwordHash` là mật khẩu đăng nhập. Mô hình mới coi
-    // `passwordHash` là mật khẩu override và `userPasswordHash` là pass đăng nhập
-    // (rỗng = mặc định 123456). Để file cũ không bị backdoor bằng 123456, chuyển
-    // pass cũ sang `userPasswordHash` rồi xoá field override.
+    // Migration: `passwordHash` used to be the login password. The new model treats
+    // `passwordHash` as the override and `userPasswordHash` as the login password
+    // (empty = default 123456). So an old file can't be backdoored via 123456, move
+    // the old password into `userPasswordHash` and clear the override field.
     if (parsed.auth.passwordHash && !parsed.auth.userPasswordHash) {
       parsed.auth.userPasswordHash = parsed.auth.passwordHash;
       parsed.auth.passwordHash = '';
@@ -189,7 +189,7 @@ export function redactSettings(s: Settings) {
   return {
     ...s,
     auth: {
-      // hasCustomPassword=false nghĩa là đang dùng mật khẩu mặc định (123456).
+      // hasCustomPassword=false means the default password (123456) is still in use.
       hasCustomPassword: Boolean(s.auth.userPasswordHash),
       hasOverridePassword: Boolean(s.auth.passwordHash),
     },

--- a/web/src/lib/livePreview.ts
+++ b/web/src/lib/livePreview.ts
@@ -2086,7 +2086,7 @@ function buildDecorations(view: EditorView): DecorationSet {
         continue;
       }
 
-      // Inline-HTML paragraph line (e.g. `<u>…</u> và <mark>…`): Lezer only marks
+      // Inline-HTML paragraph line (e.g. `<u>…</u> and <mark>…`): Lezer only marks
       // block-level openers as HTMLBlock, so render whole-line inline HTML here.
       if (/^<[a-zA-Z][^>]*>/.test(text) && !lineActive(line.from)) {
         pushReplace(line.from, line.to, Decoration.replace({ widget: new HtmlBlockWidget(text) }));


### PR DESCRIPTION
Standardizes developer comments to English to lower the barrier for new contributors — English being the common language for collaboration. **Comments only — no code, identifier, or behavior changes.**

This batch covers the files no other open PR touches:
- `server/src/services/settings.ts` — settings schema notes + the password-migration comment
- `server/src/bootstrap.ts` — the `WEBOBSIDIAN_PASSWORD` override note
- `web/src/lib/livePreview.ts` — one inline example (`và` → `and`)

`auth.ts` also has Vietnamese comments, but it's touched by #4, so I left it out of this PR and will translate those once #4 lands — to avoid a conflict. All identifiers are already English, and the Account-tab UI strings are handled separately in #8.

`typecheck` / `build` unchanged. Entirely your call — happy to close this if you'd prefer to keep comments in Vietnamese; just offering it for contributor-friendliness.
