### PR TITLE
fix(theme): dark-mode inherited text rendered unthemed (dark-on-dark labels)

### DIFF
--- a/web/src/styles/obsidian.css
+++ b/web/src/styles/obsidian.css
@@ -228,7 +228,16 @@
 
 * { box-sizing: border-box; }
 html, body, #root { height: 100%; margin: 0; }
-.theme-light, .theme-dark { height: 100%; }
+/* The palette vars (--text-normal, --background-primary, …) are defined on these
+   theme classes, but `body` (their parent) can't see them, so anything relying on
+   inherited color/background fell back to an unthemed default — e.g. setting-row
+   labels rendered dark-on-dark. Establish the themed base here, in the scope where
+   the vars actually resolve, so every descendant inherits correctly. */
+.theme-light, .theme-dark {
+  height: 100%;
+  color: var(--text-normal);
+  background-color: var(--background-primary);
+}
 body {
   font-family: var(--font-ui);
   color: var(--text-normal);


### PR DESCRIPTION
Fixes dark-on-dark text in dark mode — most visibly the settings-row labels (on the GitHub Sync tab, "Enable git sync", "Remote URL", "Branch", etc. render near-black).

### Cause
The palette vars (`--text-normal`, `--background-primary`, …) are defined on the `.theme-light` / `.theme-dark` wrapper `<div>`. But `body { color: var(--text-normal) }` runs on `body` — the wrapper's **parent** — where those vars aren't in scope, so the base (inherited) text color falls back to an unthemed default.

Elements that set `color` explicitly are fine (inputs → `--text-normal`, `.desc` → `--text-muted`). Elements that rely on **inherited** color break: `.setting-row .info .name` sets only `font-weight`, so it inherits the unthemed default and renders dark-on-dark.

### Fix
Establish the themed `color` / `background-color` on the `.theme-light` / `.theme-dark` wrapper itself — the scope where the vars actually resolve — so every descendant inherits a themed color. One-line root fix, no behavior change. `npm run -w web build` is clean.
