### PR TITLE
fix(livePreview): apply CommonMark delimiter rules to table-cell italics

### DIFF
--- a/web/src/lib/livePreview.ts
+++ b/web/src/lib/livePreview.ts
@@ -878,8 +878,12 @@ function scanTables(doc: Text): TableBlock[] {
 
 // Lightweight inline renderer for table cells (code / bold / italic / links).
 // `<br>` is the only inline HTML Obsidian commonly renders inside table cells.
+//
+// The `_…_` branch carries CommonMark's delimiter rules — `_` may not open or
+// close inside a word — or a cell holding `DB_NAME_v2` renders `_NAME_` as italic
+// and swallows the underscores. `*` is legal intraword, so it keeps the loose form.
 const CELL_INLINE_RE =
-  /(<br\s*\/?>)|(`[^`]+`)|(\*\*[^*]+\*\*)|(\*[^*]+\*|_[^_]+_)|(!?\[\[[^\]]+?\]\])|(\[[^\]]+?\]\([^)]+\))/gi;
+  /(<br\s*\/?>)|(`[^`]+`)|(\*\*[^*]+\*\*)|(\*[^*]+\*|(?<![\w\\])_(?!\s)[^_\n]+?(?<!\s)_(?!\w))|(!?\[\[[^\]]+?\]\])|(\[[^\]]+?\]\([^)]+\))/gi;
 
 function appendInline(parent: HTMLElement, text: string) {
   CELL_INLINE_RE.lastIndex = 0;


### PR DESCRIPTION
Addresses the table-cell half of #5.

The table-cell inline renderer matches italics with `_[^_]+_`, which has no notion of word boundaries, so identifiers and paths inside a cell get mangled — `DB_NAME_v2` renders `_NAME_` as italic and swallows the underscores, and `/home/a_b/c_d/` becomes `_b/c_`.

This adds CommonMark's delimiter-run constraints to the underscore branch only. `*` is legal intraword, so the loose form stays correct for asterisks.

| input | before | after |
|---|---|---|
| `DB_NAME_v2` | `_NAME_` italic | none |
| `/home/a_b/c_d/` | `_b/c_` | none |
| `this is _real emphasis_ here` | correct | correct |
| `snake_case and _emph_ mixed` | `_case and _` | `_emph_` |
| `a _ b _ c` | `_ b _` | none |

The last two are not fixed by the regex proposed in #5, which omits the right-flanking check.

**Not included: the other half of #5.** It proposes narrowing `/Mark$/` to `EmphasisMark` in the conceal loop, but that loop also covers `InlineCode` and `Strikethrough`, whose marks are `CodeMark` and `StrikethroughMark` — narrowing it would stop concealing backticks and `~~` in live preview. The stated cause also does not reproduce: parsing `/home/odoo18_up/pancake_sync/` and `odoo18_up_pancake_stock_sync` with the editor's own `@lezer/markdown` + GFM parser yields no inline nodes at all, and there is no `UnderscoreMark` node type. The reported symptom looks like this table-cell regex, which is a separate code path. (`appendInline` also already resets `lastIndex` on entry, so the state concern raised there is handled.)