### PR TITLE
fix(auth): reject the default password once an override is configured

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -4,7 +4,7 @@
 > Quy ước: `[ ]` chưa làm · `[~]` đang làm · `[x]` xong.
 > Cập nhật file này **mỗi khi** một mục thay đổi trạng thái.
 
-Cập nhật lần cuối: 2026-06-27 (security fix — chặn leo thang quyền token share; merge fix F-03 rate-limit, giữ `trust proxy` mặc định bật)
+Cập nhật lần cuối: 2026-07-27 (security fix: the default password stayed valid after an override was configured; removed the `mustChangePassword` oracle from `/auth/status`)
 
 ---
 
@@ -430,6 +430,32 @@ Cập nhật lần cuối: 2026-06-27 (security fix — chặn leo thang quyền
       `desktop/release`.
 
 ### Nhật ký tiến độ
+- 2026-07-27 (security fix: default password `123456` still accepted after an override was configured):
+  `checkPassword()` (server/src/services/auth.ts) only skipped the default-password branch when
+  `auth.userPasswordHash` was set. Configuring `WEBOBSIDIAN_PASSWORD` or a hand-edited `auth.passwordHash`
+  does **not** populate that field (`bootstrap.ts` deliberately only logs), so an operator who followed the
+  documented Docker path (`.env.example` calls it the "Initial master password", `docker-compose.yml` says
+  "Set an initial password"), set a strong secret and never opened the UI **still had `123456` accepted as a
+  full owner session**: the whole vault, `/api/settings`, `/api/keys`, `/api/git` including the stored PAT,
+  and the WebSocket stream. `GET /auth/status` made this trivially discoverable: it requires no auth and
+  returned `mustChangePassword`, which is exactly `userPasswordHash === ''`, so a port scan identified every
+  instance that would accept the default.
+  **Fix, in 4 places:** (1) new `server/src/services/password-policy.ts` exporting
+  `isDefaultPasswordActive(auth)`, true only when none of `userPasswordHash` / `passwordHash` /
+  `config.initialPassword` is set (a separate module so `auth.ts` and `settings.ts` can share one condition
+  without an import cycle). (2) `checkPassword()` gates the default branch on it. (3) `hasCustomPassword()`
+  and `redactSettings()` derive from the **same** predicate, so the "must change" signal can never disagree
+  with "is the default accepted"; that drift was the actual bug, and disagreement would strand the user,
+  since ForceChangePassword submits `changePassword('123456', ...)`. (4) `GET /auth/status` now returns only
+  `{ passwordSet }`; the client only ever read that field (`Login.tsx`), and `mustChangePassword` remains
+  available post-login on `/auth/login` and `/auth/me`.
+  *Deliberate side effect:* the desktop shell injects its per-install secret as `WEBOBSIDIAN_PASSWORD`, so
+  `123456` is now never valid on the loopback server even if `autoLogin()` fails, which previously left it live.
+  Verified against a running server, 3 scenarios / 8 assertions: with an env password set `123456` is
+  rejected (401) and the configured password accepted (200); with only a hand-edited recovery hash `123456`
+  is rejected and the recovery password accepted; with nothing configured `123456` still works (200) and
+  login reports `mustChangePassword: true`, preserving the documented first-run flow. `/auth/status` returns
+  `{"passwordSet":true}` with no `mustChangePassword` key. Typecheck + build clean.
 - 2026-06-27 (security fix — leo thang quyền qua token share): `verifyToken()` (server/src/services/auth.ts)
   chỉ kiểm tra chữ ký nên **mọi** token ký bằng `auth.jwtSecret` đều được chấp nhận như phiên owner. Endpoint
   public `POST /public/shares/:id/unlock` ký unlock-cookie bằng cùng secret → người được chia sẻ (có mật khẩu

--- a/PRD.md
+++ b/PRD.md
@@ -416,8 +416,11 @@ Express + SPA hiện có (không fork code, không đổi kiến trúc) — nên
   (chặn `..`, segment `.git`, symlink thoát vault), CORS hạn chế, rate limiting (cả `/auth/login`:
   10 lần/15 phút — **khóa theo địa chỉ socket TCP thật, không theo `req.ip`/`X-Forwarded-For`** nên
   không thể bypass bằng cách xoay vòng XFF, **bất kể cấu hình `trust proxy`**; vì vậy `trust proxy` để
-  mặc định bật (`true`, qua `TRUST_PROXY`) cho `X-Forwarded-Proto`/Secure-cookie hoạt động sau proxy). Bắt buộc đổi mật khẩu mặc định (`123456`) ngay sau lần đăng nhập đầu
-  (`mustChangePassword`). Security headers qua `helmet` + CSP (script-src 'self'+nonce; không ép HTTPS
+  mặc định bật (`true`, qua `TRUST_PROXY`) cho `X-Forwarded-Proto`/Secure-cookie hoạt động sau proxy). The default password (`123456`) is **only accepted when no other credential has
+  been configured** (`auth.userPasswordHash`, `auth.passwordHash`, or the `WEBOBSIDIAN_PASSWORD` env
+  var); only then is changing it mandatory right after the first login (`mustChangePassword`). That flag
+  is **not** returned by `GET /auth/status` (an unauthenticated route), so it cannot be used to discover
+  which instances still accept the default; clients read it from `/auth/login` and `/auth/me`. Security headers qua `helmet` + CSP (script-src 'self'+nonce; không ép HTTPS
   để giữ self-host HTTP). Token git/PAT được redact khỏi mọi thông báo lỗi trả client + log. WebSocket
   `/ws` yêu cầu phiên đăng nhập hợp lệ. Plugin `id` được validate trước khi thành path segment; đổi
   `vault.path` qua API bị giới hạn trong `allowedRoots`.

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -35,8 +35,12 @@ function cookieOpts(req: Request) {
 authRouter.get(
   '/status',
   asyncHandler(async (_req, res) => {
-    // mustChangePassword=true ⇒ still on the default 123456; the UI forces a change.
-    res.json({ passwordSet: await isPasswordSet(), mustChangePassword: !(await hasCustomPassword()) });
+    // Do NOT report `mustChangePassword` here. This route needs no auth, so the
+    // flag was a public oracle for "this instance still accepts 123456": a port
+    // scan was enough to find every takeable deployment.
+    // The client only reads `passwordSet` from here (web/src/components/Login.tsx);
+    // the flag is available post-login on /auth/login and /auth/me.
+    res.json({ passwordSet: await isPasswordSet() });
   }),
 );
 

--- a/server/src/services/auth.ts
+++ b/server/src/services/auth.ts
@@ -2,6 +2,7 @@ import { scrypt, randomBytes, timingSafeEqual, createHash } from 'node:crypto';
 import { promisify } from 'node:util';
 import jwt from 'jsonwebtoken';
 import { getSettings, updateSettings } from './settings.js';
+import { isDefaultPasswordActive } from './password-policy.js';
 import { config } from '../config.js';
 
 const scryptAsync = promisify(scrypt);
@@ -42,10 +43,16 @@ export async function isPasswordSet(): Promise<boolean> {
   return true;
 }
 
-/** Đã đổi pass khỏi mặc định chưa? */
+/**
+ * Has the instance moved off the default password yet? "Custom" here includes an
+ * operator-configured override (`auth.passwordHash` / `WEBOBSIDIAN_PASSWORD`), not
+ * just a password set through the UI: once an override exists, `123456` is no
+ * longer accepted (see `isDefaultPasswordActive`), so we must not force the user
+ * to go and change it.
+ */
 export async function hasCustomPassword(): Promise<boolean> {
   const s = await getSettings();
-  return Boolean(s.auth.userPasswordHash);
+  return !isDefaultPasswordActive(s.auth);
 }
 
 /** Lưu mật khẩu người dùng mới (ghi đè pass mặc định/pass cũ). */
@@ -68,10 +75,12 @@ export async function setUserPassword(password: string): Promise<void> {
 export async function checkPassword(password: string): Promise<boolean> {
   const s = await getSettings();
 
-  // (1) Mật khẩu đăng nhập hiệu dụng.
+  // (1) The effective login password. The default branch must go through
+  // isDefaultPasswordActive(): it previously tested `userPasswordHash` alone, so
+  // setting WEBOBSIDIAN_PASSWORD without ever opening the UI still let `123456` in.
   if (s.auth.userPasswordHash) {
     if (await verifyPassword(password, s.auth.userPasswordHash)) return true;
-  } else if (safeEqualStr(password, DEFAULT_PASSWORD)) {
+  } else if (isDefaultPasswordActive(s.auth) && safeEqualStr(password, DEFAULT_PASSWORD)) {
     return true;
   }
 

--- a/server/src/services/password-policy.ts
+++ b/server/src/services/password-policy.ts
@@ -1,0 +1,30 @@
+import { config } from '../config.js';
+
+/**
+ * The built-in default password (`123456`) is only accepted when NO other
+ * credential has been configured.
+ *
+ * This condition previously looked at `userPasswordHash` alone, so an instance
+ * that set `WEBOBSIDIAN_PASSWORD` (or a hand-edited `auth.passwordHash`) and
+ * never opened the UI still accepted `123456` as a full owner session, which is
+ * exactly the deployment path `.env.example` ("Initial master password") and
+ * `docker-compose.yml` document.
+ *
+ * It lives in its own module because two places must share one condition:
+ *  - `checkPassword()`: is the default accepted?
+ *  - `hasCustomPassword()` -> `mustChangePassword`: must the user change it?
+ *
+ * Those two drifting apart is the root of the bug. Keeping a single function
+ * also guarantees we never force a change to a default that no longer works:
+ * the ForceChangePassword screen submits `changePassword('123456', ...)`, which
+ * would fail if the two conditions disagreed.
+ *
+ * Takes just the two hashes rather than `Settings` so this module never imports
+ * `settings.ts`, which would create an import cycle.
+ */
+export function isDefaultPasswordActive(auth: {
+  userPasswordHash: string;
+  passwordHash: string;
+}): boolean {
+  return !auth.userPasswordHash && !auth.passwordHash && !config.initialPassword;
+}

--- a/server/src/services/settings.ts
+++ b/server/src/services/settings.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { randomBytes } from 'node:crypto';
 import { z } from 'zod';
 import { config, SETTINGS_FILE } from '../config.js';
+import { isDefaultPasswordActive } from './password-policy.js';
 
 /** ---- Schema (PRD §6) ---------------------------------------------------- */
 
@@ -190,7 +191,10 @@ export function redactSettings(s: Settings) {
     ...s,
     auth: {
       // hasCustomPassword=false nghĩa là đang dùng mật khẩu mặc định (123456).
-      hasCustomPassword: Boolean(s.auth.userPasswordHash),
+      // Shares one condition with checkPassword: once an override is configured
+      // (auth.passwordHash / WEBOBSIDIAN_PASSWORD) the default no longer works, so
+      // the UI must stop warning that the instance is on the default password.
+      hasCustomPassword: !isDefaultPasswordActive(s.auth),
       hasOverridePassword: Boolean(s.auth.passwordHash),
     },
     git: { ...s.git, token: s.git.token ? '••••••••' : '' },

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -89,7 +89,10 @@ export class ApiError extends Error {
 
 export const api = {
   // auth
-  authStatus: () => req<{ passwordSet: boolean; mustChangePassword: boolean }>('/auth/status'),
+  // /auth/status is unauthenticated, so it deliberately reports nothing about
+  // whether the default password is still in use. mustChangePassword comes from
+  // /auth/login and /auth/me instead.
+  authStatus: () => req<{ passwordSet: boolean }>('/auth/status'),
   setup: (password: string) =>
     req<{ ok: true }>('/auth/setup', { method: 'POST', body: JSON.stringify({ password }) }),
   login: (password: string) =>


### PR DESCRIPTION
## Summary

`checkPassword()` only skips the default-password branch when `auth.userPasswordHash` is set. Setting `WEBOBSIDIAN_PASSWORD` or a hand-edited `auth.passwordHash` does **not** populate that field (`bootstrap.ts` deliberately only logs), so an operator who follows the documented Docker path, sets a strong secret and never opens the UI **still has `123456` accepted as a full owner session**: the whole vault, `/api/settings`, `/api/keys`, `/api/git` including the stored PAT, and the WebSocket stream.

This is the documented deployment, not an unusual one. `.env.example` calls the variable the "Initial master password" and `docker-compose.yml` says "Set an initial password".

`GET /auth/status` made it trivially discoverable: it needs no auth and returned `mustChangePassword`, which is exactly `userPasswordHash === ''`. A port scan was enough to identify every instance that would accept the default.

**Fix.** A new `server/src/services/password-policy.ts` exports `isDefaultPasswordActive(auth)`, true only when none of `userPasswordHash`, `auth.passwordHash` or `config.initialPassword` is set. It is its own module so `auth.ts` and `settings.ts` can share one condition without an import cycle. `checkPassword()`, `hasCustomPassword()` and `redactSettings()` all now derive from that single predicate.

Sharing the predicate matters beyond tidiness: `ForceChangePassword` submits `changePassword('123456', ...)`, so a state where the default is rejected but a change is still forced would strand the user at an unpassable wall. `GET /auth/status` now returns only `{ passwordSet }`; `Login.tsx` only ever read that field, and `mustChangePassword` is still available post-login on `/auth/login` and `/auth/me`.

Deliberate side effect: the desktop shell injects its per-install secret as `WEBOBSIDIAN_PASSWORD`, so `123456` is now never valid on the loopback server even when `autoLogin()` fails, which previously left it live.

## Related

PRD §4 (NFR, security). Credit where due: #4 by @metaember targets the same default-password behaviour and is still open. This PR takes a different implementation route (one shared predicate rather than a check at the call site) and additionally closes the `/auth/status` disclosure, which I did not find described elsewhere.

Contributed by [Lattice Labs](https://github.com/latticelabs-au).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Docs only

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm run build` succeeds
- [x] Updated [PRD.md](../PRD.md) if design/scope changed (with changelog bump)
- [x] Updated [IMPLEMENTATION_PLAN.md](../IMPLEMENTATION_PLAN.md) checkboxes + progress log
- [x] No secrets/tokens logged; paths guarded against traversal

## Screenshots / notes

Verified against a running server, 3 scenarios / 8 assertions:

| Scenario | `123456` | Configured credential |
|---|---|---|
| `WEBOBSIDIAN_PASSWORD` set, UI never opened | 401 rejected | 200 accepted |
| hand-edited `auth.passwordHash`, no env var | 401 rejected | 200 accepted |
| nothing configured (documented first run) | 200 accepted | n/a, `mustChangePassword: true` |

`GET /auth/status` returns `{"passwordSet":true}` with no `mustChangePassword` key. The third row is the important regression check: the documented first-run flow is unchanged, so a fresh instance still logs in with the default and is still forced to change it.

Desktop typecheck and desktop build also pass. The diff is deliberately minimal and touches no route paths, cookie names or stored values.
