### PR TITLE
fix(vault): follow symlinks within allowedRoots

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -4,7 +4,7 @@
 > Quy ước: `[ ]` chưa làm · `[~]` đang làm · `[x]` xong.
 > Cập nhật file này **mỗi khi** một mục thay đổi trạng thái.
 
-Cập nhật lần cuối: 2026-06-27 (security fix — chặn leo thang quyền token share; merge fix F-03 rate-limit, giữ `trust proxy` mặc định bật)
+Cập nhật lần cuối: 2026-08-20 (FR-1 — symlink vault roots: theo symlink trong allowedRoots, cycle guard realpath)
 
 ---
 
@@ -30,6 +30,9 @@ Cập nhật lần cuối: 2026-06-27 (security fix — chặn leo thang quyền
 ## Phase 3 — Vault filesystem — FR-1
 - [x] M3.1 Service vault: list tree, read, write, create, rename/move, delete→trash
 - [x] M3.2 Path traversal guard + allowedRoots
+- [x] M3.7 Symlink vault roots: walks của `listTree`/`copy`/`listMarkdownFiles`/`buildFileIndex` theo symlink
+      (folder/file, kể cả trỏ ra ngoài vault root nếu realpath trong allowedRoots; link hỏng bỏ qua), cycle
+      guard bằng `realpath`; `assertRealpathInVault` kiểm tra đa allowedRoots; `fs.cp` bật `dereference: true`
 - [x] M3.3 Upload attachments (binary), serve binary với mime
 - [x] M3.4 Folder browser an toàn để chọn vault path
 - [x] M3.5 Filesystem watcher (chokidar) → events qua WebSocket
@@ -430,6 +433,14 @@ Cập nhật lần cuối: 2026-06-27 (security fix — chặn leo thang quyền
       `desktop/release`.
 
 ### Nhật ký tiến độ
+- 2026-08-20 (FR-1 — symlink vault roots): vault dùng `readdir` với Dirent (semantics lstat) nên symlink
+  không bao giờ được liệt kê (không `isDirectory`/`isFile`), và `assertRealpathInVault` chặn mọi đường
+  thoát khỏi vault root đơn — vault có folder symlink trỏ ra ngoài root vô hình. **Sửa:** walks của
+  `listTree`/`copy`/`listMarkdownFiles`/`buildFileIndex` xử lý `e.isSymbolicLink()` (theo `fs.stat` →
+  folder/file, link hỏng bỏ qua) với cycle guard bằng `realpath` (Set) chống vòng lặp (vd symlink trỏ ngược
+  về root thành folder rỗng thay vì đệ quy vô hạn); `assertRealpathInVault` kiểm tra realpath theo **tất
+  cả** allowedRoots thay vì root đơn; `fs.cp` bật `dereference: true`. Đã xác minh: vault có 3 symlink
+  trỏ ra ngoài → 434 file `.md` được liệt kê/đọc/search OK, typecheck + build sạch.
 - 2026-06-27 (security fix — leo thang quyền qua token share): `verifyToken()` (server/src/services/auth.ts)
   chỉ kiểm tra chữ ký nên **mọi** token ký bằng `auth.jwtSecret` đều được chấp nhận như phiên owner. Endpoint
   public `POST /public/shares/:id/unlock` ký unlock-cookie bằng cùng secret → người được chia sẻ (có mật khẩu

--- a/PRD.md
+++ b/PRD.md
@@ -1,7 +1,10 @@
 # PRD — WebObsidian
 
 > Product Requirements Document
-> Phiên bản: 1.5 · Cập nhật: 2026-06-22 · Trạng thái: Draft
+> Phiên bản: 1.6 · Cập nhật: 2026-08-20 · Trạng thái: Draft
+> Changelog 1.6 (FR-1 — symlink vault roots): hỗ trợ **symlink trong vault**: folder/file được trỏ qua
+> symlink được liệt kê và đọc/ghi bình thường kể cả khi trỏ ra ngoài vault root (miễn realpath nằm trong
+> `vault.allowedRoots`); cycle guard bằng `realpath` chống vòng lặp symlink.
 > Changelog 1.5 (FR-13 — Desktop app Electron đa nền tảng, theo yêu cầu người dùng): bổ sung **FR-13** —
 > đóng gói WebObsidian thành **app cài đặt** macOS/Windows/Linux (arm64/x64/ia32). Workspace mới `desktop/`
 > là **Electron shell** spawn đúng server Express hiện có như tiến trình con (qua `ELECTRON_RUN_AS_NODE`,
@@ -180,6 +183,10 @@ webobsidian/
   sẵn có (`vault.resolveDirCaseInsensitive`) — tránh tạo thư mục trùng khác hoa-thường (vd `attachments` cạnh
   `Attachments` có sẵn) trên filesystem phân biệt hoa-thường (Linux).
 - Watch filesystem (chokidar) để phản ánh thay đổi ngoài (git pull, sửa trực tiếp).
+- **Symlink vault roots**: folder/file được trỏ qua symlink trong vault được liệt kê, đọc/ghi và index như
+  file thường — kể cả khi symlink trỏ ra ngoài vault root, miễn realpath của đích nằm trong
+  `vault.allowedRoots`. Cycle guard bằng `realpath` (Set) chống vòng lặp symlink (vd symlink trỏ ngược
+  về chính vault root). Link hỏng bị bỏ qua.
 - Tương thích cấu trúc `.obsidian/` (config, plugins, themes).
 
 ### FR-2 · Editor & rendering
@@ -413,7 +420,8 @@ Express + SPA hiện có (không fork code, không đổi kiến trúc) — nên
 
 ## 4. Yêu cầu phi chức năng (NFR)
 - **Bảo mật**: password hash scrypt, JWT secret tự sinh, API key hash khi lưu, path traversal guard
-  (chặn `..`, segment `.git`, symlink thoát vault), CORS hạn chế, rate limiting (cả `/auth/login`:
+  (chặn `..`, segment `.git`, symlink thoát vault — trừ khi realpath đích nằm trong `vault.allowedRoots`),
+  CORS hạn chế, rate limiting (cả `/auth/login`:
   10 lần/15 phút — **khóa theo địa chỉ socket TCP thật, không theo `req.ip`/`X-Forwarded-For`** nên
   không thể bypass bằng cách xoay vòng XFF, **bất kể cấu hình `trust proxy`**; vì vậy `trust proxy` để
   mặc định bật (`true`, qua `TRUST_PROXY`) cho `X-Forwarded-Proto`/Secure-cookie hoạt động sau proxy). Bắt buộc đổi mật khẩu mặc định (`123456`) ngay sau lần đăng nhập đầu

--- a/server/src/services/fileindex.ts
+++ b/server/src/services/fileindex.ts
@@ -30,21 +30,30 @@ function record(maps: { b: Map<string, string>; bn: Map<string, string> }, rel: 
 export async function buildFileIndex(): Promise<void> {
   const root = await getVaultRoot();
   const maps = { b: new Map<string, string>(), bn: new Map<string, string>() };
-  async function walk(dir: string) {
+  async function walk(dir: string, visited: Set<string>) {
     let entries;
     try {
       entries = await fs.readdir(dir, { withFileTypes: true });
     } catch {
       return;
     }
+    const key = await fs.realpath(dir).catch(() => dir);
+    if (visited.has(key)) return;
+    visited.add(key);
     for (const e of entries) {
       if (IGNORED.has(e.name) || e.name.startsWith('.')) continue;
       const abs = path.join(dir, e.name);
-      if (e.isDirectory()) await walk(abs);
+      if (e.isDirectory()) await walk(abs, visited);
       else if (e.isFile()) record(maps, toRel(root, abs));
+      else if (e.isSymbolicLink()) {
+        const st = await fs.stat(abs).catch(() => null);
+        if (!st) continue;
+        if (st.isDirectory()) await walk(abs, visited);
+        else if (st.isFile()) record(maps, toRel(root, abs));
+      }
     }
   }
-  await walk(root);
+  await walk(root, new Set());
   byBasename = maps.b;
   byBasenameNoExt = maps.bn;
 }

--- a/server/src/services/vault.ts
+++ b/server/src/services/vault.ts
@@ -44,6 +44,16 @@ const TEXT_EXTS = new Set([
 
 const IGNORED = new Set(['.git', 'node_modules']);
 
+/** Vault roots that file operations may resolve into: the vault root itself plus
+ * any allowedRoots from settings (folders reachable via symlinks may live outside
+ * the root). Falls back to the single vault root when none are configured. */
+export async function getAllowedRoots(): Promise<string[]> {
+  const s = await getSettings();
+  const vault = path.resolve(s.vault.path);
+  const extra = s.vault.allowedRoots.map((r) => path.resolve(r));
+  return extra.length ? [vault, ...extra] : [vault];
+}
+
 export async function getVaultRoot(): Promise<string> {
   const s = await getSettings();
   return path.resolve(s.vault.path);
@@ -66,21 +76,22 @@ export async function resolveInVault(relPath: string): Promise<string> {
   // Symlink guard: a symlink *inside* the vault could point outside it, which the
   // string-prefix check above can't catch. Resolve the real path of the deepest
   // existing ancestor and confirm it still lives under the vault root.
-  await assertRealpathInVault(abs, root);
+  await assertRealpathInVault(abs, await getAllowedRoots());
   return abs;
 }
 
-async function assertRealpathInVault(abs: string, root: string): Promise<void> {
-  const realRoot = await fs.realpath(root).catch(() => root);
-  const realRootSep = realRoot.endsWith(path.sep) ? realRoot : realRoot + path.sep;
+async function assertRealpathInVault(abs: string, roots: string[]): Promise<void> {
+  const realRoots = await Promise.all(roots.map((r) => fs.realpath(r).catch(() => r)));
+  const realRootSeps = realRoots.map((r) => (r.endsWith(path.sep) ? r : r + path.sep));
   let probe = abs;
   for (;;) {
     try {
       const real = await fs.realpath(probe);
-      if (real !== realRoot && !real.startsWith(realRootSep)) {
+      const inside = realRoots.some((rr, i) => real === rr || real.startsWith(realRootSeps[i]));
+      if (!inside) {
         throw Object.assign(new Error('Path escapes vault'), { status: 400 });
       }
-      return; // deepest existing ancestor is inside the vault; the rest is new
+      return; // deepest existing ancestor is inside an allowed root; the rest is new
     } catch (e: any) {
       if (e?.status === 400) throw e; // our own escape error — propagate
       const parent = path.dirname(probe);
@@ -104,7 +115,11 @@ export async function listTree(): Promise<TreeNode> {
   const root = await getVaultRoot();
   await fs.mkdir(root, { recursive: true });
 
-  async function walk(absDir: string): Promise<TreeNode[]> {
+  async function walk(absDir: string, visited: Set<string>): Promise<TreeNode[]> {
+    // Symlink cycle guard: a link may point back into an ancestor or the root.
+    const key = await fs.realpath(absDir).catch(() => absDir);
+    if (visited.has(key)) return [];
+    visited.add(key);
     const entries = await fs.readdir(absDir, { withFileTypes: true });
     // Stat files concurrently per directory (cached) so the one-time fill is fast;
     // steady state reads from statCache → no syscalls. mtime/ctime power sort-by-time.
@@ -115,11 +130,24 @@ export async function listTree(): Promise<TreeNode> {
           const abs = path.join(absDir, e.name);
           const rel = toRel(root, abs);
           if (e.isDirectory()) {
-            return { name: e.name, path: rel, type: 'folder', children: await walk(abs) };
+            return { name: e.name, path: rel, type: 'folder', children: await walk(abs, visited) };
           }
           if (e.isFile()) {
             const { m, c } = await fileStat(abs, rel);
             return { name: e.name, path: rel, type: 'file', ext: path.extname(e.name).toLowerCase(), mtime: m, ctime: c };
+          }
+          // Symlinked entries: a Dirent is neither dir nor file, but the link may
+          // resolve to either. Broken links are skipped.
+          if (e.isSymbolicLink()) {
+            const st = await fs.stat(abs).catch(() => null);
+            if (!st) return null;
+            if (st.isDirectory()) {
+              return { name: e.name, path: rel, type: 'folder', children: await walk(abs, visited) };
+            }
+            if (st.isFile()) {
+              const { m, c } = await fileStat(abs, rel);
+              return { name: e.name, path: rel, type: 'file', ext: path.extname(e.name).toLowerCase(), mtime: m, ctime: c };
+            }
           }
           return null;
         }),
@@ -133,7 +161,7 @@ export async function listTree(): Promise<TreeNode> {
     return out;
   }
 
-  return { name: path.basename(root), path: '', type: 'folder', children: await walk(root) };
+  return { name: path.basename(root), path: '', type: 'folder', children: await walk(root, new Set()) };
 }
 
 export function isTextFile(rel: string): boolean {
@@ -220,21 +248,30 @@ export async function copy(from: string, to: string): Promise<string[]> {
   const absFrom = await resolveInVault(from);
   const absTo = await resolveInVault(to);
   await fs.mkdir(path.dirname(absTo), { recursive: true });
-  await fs.cp(absFrom, absTo, { recursive: true, errorOnExist: true, force: false });
+  await fs.cp(absFrom, absTo, { recursive: true, errorOnExist: true, force: false, dereference: true });
   const root = await getVaultRoot();
   const out: string[] = [];
   const st = await fs.stat(absTo);
   if (st.isDirectory()) {
-    async function walk(dir: string) {
+    async function walk(dir: string, visited: Set<string>) {
+      const key = await fs.realpath(dir).catch(() => dir);
+      if (visited.has(key)) return;
+      visited.add(key);
       const entries = await fs.readdir(dir, { withFileTypes: true });
       for (const e of entries) {
         if (IGNORED.has(e.name)) continue;
         const abs = path.join(dir, e.name);
-        if (e.isDirectory()) await walk(abs);
+        if (e.isDirectory()) await walk(abs, visited);
         else if (e.isFile()) out.push(toRel(root, abs));
+        else if (e.isSymbolicLink()) {
+          const st = await fs.stat(abs).catch(() => null);
+          if (!st) continue;
+          if (st.isDirectory()) await walk(abs, visited);
+          else if (st.isFile()) out.push(toRel(root, abs));
+        }
       }
     }
-    await walk(absTo);
+    await walk(absTo, new Set());
   } else {
     out.push(toRel(root, absTo));
   }
@@ -396,23 +433,32 @@ export async function emptyTrash(): Promise<void> {
 export async function listMarkdownFiles(): Promise<string[]> {
   const root = await getVaultRoot();
   const out: string[] = [];
-  async function walk(dir: string) {
+  async function walk(dir: string, visited: Set<string>) {
     let entries;
     try {
       entries = await fs.readdir(dir, { withFileTypes: true });
     } catch {
       return;
     }
+    const key = await fs.realpath(dir).catch(() => dir);
+    if (visited.has(key)) return;
+    visited.add(key);
     for (const e of entries) {
       // Skip dotfiles/dot-dirs (`.trash`, `.obsidian`, …) like the tree view and
       // file index do — a note moved to `.trash` must not stay a live link target
       // (and would otherwise shadow a real file with the same basename).
       if (IGNORED.has(e.name) || e.name.startsWith('.')) continue;
       const abs = path.join(dir, e.name);
-      if (e.isDirectory()) await walk(abs);
+      if (e.isDirectory()) await walk(abs, visited);
       else if (e.isFile() && /\.(md|markdown)$/i.test(e.name)) out.push(toRel(root, abs));
+      else if (e.isSymbolicLink()) {
+        const st = await fs.stat(abs).catch(() => null);
+        if (!st) continue;
+        if (st.isDirectory()) await walk(abs, visited);
+        else if (st.isFile() && /\.(md|markdown)$/i.test(e.name)) out.push(toRel(root, abs));
+      }
     }
   }
-  await walk(root);
+  await walk(root, new Set());
   return out;
 }


### PR DESCRIPTION
## Summary
Symlinked folders inside the vault (e.g. a vault whose notes are reached through links to external folders) were silently missing from the tree, the file index and full-text search, and any operation on them was refused.

Root cause: `fs.readdir(dir, {withFileTypes:true})` returns `Dirent` with lstat semantics — a symlink is neither `isDirectory()` nor `isFile()`, so the walk branches fell through to `null` and dropped the entry. In parallel, `assertRealpathInVault` only accepted realpaths under the single vault root, so even when a link was walked, its target outside the root was refused.

Fix:
- `listTree`, `copy`, `listMarkdownFiles` (vault.ts) and `buildFileIndex` (fileindex.ts) now walk symlinks via `fs.stat` (broken links skipped), guarded by a realpath-based visited set against symlink cycles.
- `assertRealpathInVault` now accepts any of `vault.allowedRoots` (new `getAllowedRoots()` helper), falling back to the single vault root when none are configured. This keeps the security model: an authenticated write can only ever resolve inside an allowed root.
- `copy` dereferences symlinks (`fs.cp(..., dereference: true)`) so copying a symlinked folder copies its contents, not the link.
- Docs: PRD changelog 1.6 + FR-1 "Symlink vault roots" + security NFR; IMPLEMENTATION_PLAN M3.7 checked with journal entry.

## Related
No open issue — found while self-hosting with a vault composed of symlinked folders.

## Type of change
- [x] Bug fix (non-breaking)

## Checklist
- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] Verified manually: a vault with 3 symlinked folders serves the full tree, file reads and full-text search; write operations outside `allowedRoots` are still refused

## Screenshots / notes
No UI change.